### PR TITLE
carry addresses within packets and messages

### DIFF
--- a/fsm.go
+++ b/fsm.go
@@ -105,9 +105,9 @@ func (s *stateMachine) tick() ([]packet, []Update) {
 		id := id(u.ID)
 		u.Addr = s.addrs[id]
 		m := s.failedMessage(id)
-		delete(s.addrs, id)
 		s.mq.update(m)
 		ps = append(ps, s.makeMessagePing(m))
+		delete(s.addrs, id)
 	}
 
 	if s.pingTarget == "" {

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 func TestSupersedes(t *testing.T) {
-	a1 := &message{alive, "abc", 1}
-	s1 := &message{suspected, "abc", 1}
-	a2 := &message{alive, "abc", 2}
-	s2 := &message{suspected, "abc", 2}
-	f := &message{failed, "abc", 0}
+	a1 := &message{Type: alive, ID: "abc", Incarnation: 1}
+	s1 := &message{Type: suspected, ID: "abc", Incarnation: 1}
+	a2 := &message{Type: alive, ID: "abc", Incarnation: 2}
+	s2 := &message{Type: suspected, ID: "abc", Incarnation: 2}
+	f := &message{Type: failed, ID: "abc", Incarnation: 0}
 	for _, test := range []struct {
 		a, b *message
 		want bool
@@ -40,8 +40,8 @@ func TestSupersedes(t *testing.T) {
 		{a2, s1, true},
 		{a1, s2, false},
 		{s2, a1, true},
-		{a2, &message{alive, "def", 1}, false},
-		{&message{alive, "def", 2}, a1, false},
+		{a2, &message{Type: alive, ID: "def", Incarnation: 1}, false},
+		{&message{Type: alive, ID: "def", Incarnation: 2}, a1, false},
 	} {
 		diff.Test(t, t.Errorf, supersedes(test.a, test.b), test.want)
 	}

--- a/swim.go
+++ b/swim.go
@@ -105,9 +105,6 @@ func (n *Node) Join(remote netip.AddrPort) {
 
 func (n *Node) send(ps []packet) {
 	for _, p := range ps {
-		if p.remoteAddr == (netip.AddrPort{}) {
-			continue
-		}
 		b := encode(n.id, p)
 		if _, err := n.conn.WriteToUDPAddrPort(b, p.remoteAddr); err != nil {
 			if errors.Is(err, net.ErrClosed) {


### PR DESCRIPTION
Address values accompanying individual message IDs have been transmitted in a separate slice in the envelope, without robust protection of their one-to-one correspondence and semantic relevance. Now that addresses are netip.AddrPort values, it's easier to keep them collocated with their corresponding IDs, within the messages themselves. This simplifies the signatures of many functions involved in encoding, sending, decoding, and receiving.