### PR TITLE
remove aliveMessage on fsm initialization

### DIFF
--- a/fsm.go
+++ b/fsm.go
@@ -72,7 +72,6 @@ func newStateMachine() *stateMachine {
 		maxMsgs:   6, // TODO: revisit guaranteed MTU constraint
 	}
 	s.mq = newMessageQueue(func() int { return len(s.ml.members) + 1 })
-	s.mq.update(s.aliveMessage())
 	return s
 }
 


### PR DESCRIPTION
Join sends a targeted alive message to its remote address each time it's
called, so the fsm doesn't need to be initialized with an indiscriminate
alive message duplicating that information in the message queue.