### PR TITLE
fix bug accepting packets from removed IDs

### DIFF
--- a/fsm.go
+++ b/fsm.go
@@ -129,6 +129,9 @@ func (s *stateMachine) timeout() []packet {
 // packets and Updates in response. The boolean return value reports whether
 // the stateMachine can continue participating in the protocol.
 func (s *stateMachine) receive(p packet) ([]packet, []Update, bool) {
+	if s.ml.removed[p.remoteID] {
+		return nil, nil, true
+	}
 	if s.addrs[p.remoteID] == (netip.AddrPort{}) {
 		// First contact from sender
 		s.addrs[p.remoteID] = p.remoteAddr


### PR DESCRIPTION
Erroneous behavior without this check:

1. A informs B that C has failed.
2. B marks C as removed and deletes its records of C's info.
3. C sends a ping to B.
4. Not recognizing C's address, B adds C's address.
5. B sends C an ack in response to this and subsequent pings (while continuing to correctly ignore messages regarding C from all sources).