### PR TITLE
use logarthmic thoroughness coefficient of 2

### DIFF
--- a/fsm.go
+++ b/fsm.go
@@ -107,8 +107,8 @@ func newStateMachine(updates chan<- Update, memos chan<- Memo) *stateMachine {
 		memos:   memos,
 	}
 
-	s.msgQueue = rpq.New[id, *message](s.logn3)
-	s.memoQueue = rpq.New[id, *message](s.logn3)
+	s.msgQueue = rpq.New[id, *message](s.logn2)
+	s.memoQueue = rpq.New[id, *message](s.logn2)
 	return s
 }
 
@@ -117,7 +117,7 @@ func newStateMachine(updates chan<- Update, memos chan<- Memo) *stateMachine {
 func (s *stateMachine) tick() []packet {
 	var ps []packet
 	for id := range s.suspects {
-		if s.suspects[id]++; s.suspects[id] >= s.logn3() {
+		if s.suspects[id]++; s.suspects[id] >= s.logn2() {
 			// Suspicion timeout
 			m := s.failedMessage(id)
 			s.msgQueue.Upsert(id, m)
@@ -262,12 +262,12 @@ func (s *stateMachine) processPacketType(p packet) []packet {
 	return nil
 }
 
-// logn3 returns 3*log(n) rounded up, where n is the size of the network.
+// logn2 returns 2*log(n) rounded up, where n is the size of the network.
 // Each message must be sent a small multiple of log(n) times to ensure
 // reliable dissemination. Consequently, this is also the number of profile
 // periods to wait before declaring a suspect failed.
-func (s *stateMachine) logn3() int {
-	return int(math.Ceil(3 * math.Log(float64(len(s.members)+1))))
+func (s *stateMachine) logn2() int {
+	return int(math.Ceil(2 * math.Log(float64(len(s.members)+1))))
 }
 
 // isMember reports whether an id is a member.

--- a/fsm.go
+++ b/fsm.go
@@ -264,8 +264,9 @@ func (s *stateMachine) processPacketType(p packet) []packet {
 
 // logn2 returns 2*log(n) rounded up, where n is the size of the network.
 // Each message must be sent a small multiple of log(n) times to ensure
-// reliable dissemination. Consequently, this is also the number of profile
-// periods to wait before declaring a suspect failed.
+// reliable dissemination. Consequently, this is also the dissemination
+// timescale, and by extension the number of profile periods to wait before
+// declaring a suspect failed.
 func (s *stateMachine) logn2() int {
 	return int(math.Ceil(2 * math.Log(float64(len(s.members)+1))))
 }


### PR DESCRIPTION
The number of times each node should send each message grows logarithmically
with the network size. The coefficient denoted by _λ_ in the paper describes the
thoroughness of message dissemination. Specifically, if each message is sent _λ_
log _n_ times, then after _λ_ log _n_ protocol periods, the number of nodes that have
not received the message tends to approach _n_^-(2_λ_-2): setting _λ_ > 1
disseminates messages with high confidence.

In a fully configurable implementation of SWIM, this would be one of the
configurable parameters, with the specific value chosen subject to tradeoffs
between thoroughness on the one hand and network traffic and failure detection
latency on the other. For however long this value is going to remain
hard-coded, 2 seems in practice just as effective as the initial draft's
arbitrary value of 3, and more lightweight.