### PR TITLE
combine types Update and Memo

### DIFF
--- a/fsm.go
+++ b/fsm.go
@@ -191,10 +191,10 @@ func (s *stateMachine) processMsg(m *message) bool {
 		s.seenMemos[m.MemoID] = true
 		s.memoQueue.Upsert(m.MemoID, m)
 		s.updates <- Update{
-			NodeID:   string(m.NodeID),
-			Addr:     m.Addr,
-			IsMember: true,
-			Body:     m.Body,
+			Type:   SentMemo,
+			NodeID: string(m.NodeID),
+			Addr:   m.Addr,
+			Memo:   m.Body,
 		}
 	case s.isMemberNews(m):
 		s.updateStatus(m)
@@ -214,7 +214,7 @@ func (s *stateMachine) updateStatus(m *message) {
 	if !s.isMember(id) {
 		s.members[id] = new(profile)
 		s.order.Add(id)
-		s.updates <- Update{NodeID: string(id), IsMember: true, Addr: m.Addr}
+		s.updates <- Update{Type: Joined, NodeID: string(id), Addr: m.Addr}
 	}
 	s.members[id].incarnation = m.Incarnation
 	s.members[id].addr = m.Addr
@@ -231,7 +231,7 @@ func (s *stateMachine) remove(id id) {
 	if !s.isMember(id) {
 		return
 	}
-	s.updates <- Update{NodeID: string(id), IsMember: false, Addr: s.members[id].addr}
+	s.updates <- Update{Type: Failed, NodeID: string(id), Addr: s.members[id].addr}
 	delete(s.members, id)
 	delete(s.suspects, id)
 	s.removed[id] = true

--- a/fsm.go
+++ b/fsm.go
@@ -190,10 +190,11 @@ func (s *stateMachine) processMsg(m *message) bool {
 		}
 		s.seenMemos[m.MemoID] = true
 		s.memoQueue.Upsert(m.MemoID, m)
-		s.memos <- Memo{
-			NodeID: string(m.NodeID),
-			Addr:   m.Addr,
-			Body:   m.Body,
+		s.updates <- Update{
+			NodeID:   string(m.NodeID),
+			Addr:     m.Addr,
+			IsMember: true,
+			Body:     m.Body,
 		}
 	case s.isMemberNews(m):
 		s.updateStatus(m)

--- a/fsm.go
+++ b/fsm.go
@@ -31,7 +31,6 @@ type stateMachine struct {
 	maxMsgs   int
 
 	updates chan<- Update
-	memos   chan<- Memo
 }
 
 // A packetType describes the meaning of a packet.
@@ -89,7 +88,7 @@ type profile struct {
 
 // newStateMachine initializes a new stateMachine emitting Updates on the
 // provided channel, which must never block.
-func newStateMachine(updates chan<- Update, memos chan<- Memo) *stateMachine {
+func newStateMachine(updates chan<- Update) *stateMachine {
 	s := &stateMachine{
 		id: randID(),
 
@@ -104,7 +103,6 @@ func newStateMachine(updates chan<- Update, memos chan<- Memo) *stateMachine {
 		maxMsgs:   6, // TODO: revisit guaranteed MTU constraint
 
 		updates: updates,
-		memos:   memos,
 	}
 
 	s.msgQueue = rpq.New[id, *message](s.disseminationFactor)

--- a/fsm.go
+++ b/fsm.go
@@ -191,9 +191,9 @@ func (s *stateMachine) processMsg(m *message) bool {
 		s.seenMemos[m.MemoID] = true
 		s.memoQueue.Upsert(m.MemoID, m)
 		s.memos <- Memo{
-			SrcID:   string(m.NodeID),
-			SrcAddr: m.Addr,
-			Body:    m.Body,
+			NodeID: string(m.NodeID),
+			Addr:   m.Addr,
+			Body:   m.Body,
 		}
 	case s.isMemberNews(m):
 		s.updateStatus(m)
@@ -213,7 +213,7 @@ func (s *stateMachine) updateStatus(m *message) {
 	if !s.isMember(id) {
 		s.members[id] = new(profile)
 		s.order.Add(id)
-		s.updates <- Update{ID: string(id), IsMember: true, Addr: m.Addr}
+		s.updates <- Update{NodeID: string(id), IsMember: true, Addr: m.Addr}
 	}
 	s.members[id].incarnation = m.Incarnation
 	s.members[id].addr = m.Addr
@@ -230,7 +230,7 @@ func (s *stateMachine) remove(id id) {
 	if !s.isMember(id) {
 		return
 	}
-	s.updates <- Update{ID: string(id), IsMember: false, Addr: s.members[id].addr}
+	s.updates <- Update{NodeID: string(id), IsMember: false, Addr: s.members[id].addr}
 	delete(s.members, id)
 	delete(s.suspects, id)
 	s.removed[id] = true

--- a/swim.go
+++ b/swim.go
@@ -17,18 +17,19 @@ const (
 	pingTimeout = 200 * time.Millisecond
 )
 
-// An Update describes a change to the network membership.
+// An Update carries network membership information or user-defined data.
 type Update struct {
-	ID       string
+	NodeID   string
 	Addr     netip.AddrPort
 	IsMember bool
+	Body     []byte
 }
 
 // A Memo carries user-defined data.
 type Memo struct {
-	SrcID   string
-	SrcAddr netip.AddrPort
-	Body    []byte
+	NodeID string
+	Addr   netip.AddrPort
+	Body   []byte
 }
 
 // A Node is a network node participating in the SWIM protocol.

--- a/swim.go
+++ b/swim.go
@@ -157,10 +157,10 @@ func (n *Node) receive(p packet) ([]packet, bool) {
 	return n.fsm.receive(p)
 }
 
-// PostMemo disseminates b throughout the network. To ensure transmission
-// within a single UDP packet, PostMemo enforces a length limit of 500 bytes;
-// if len(b) exceeds this, PostMemo returns an error instead.
-func (n *Node) PostMemo(b []byte) error {
+// Post disseminates b throughout the network. To ensure transmission within a
+// single UDP packet, Post enforces a length limit of 500 bytes; if len(b)
+// exceeds this, Post returns an error instead.
+func (n *Node) Post(b []byte) error {
 	if len(b) > 500 {
 		return errors.New("body too long")
 	}

--- a/swim_test.go
+++ b/swim_test.go
@@ -50,6 +50,12 @@ func TestPost(t *testing.T) {
 	addr0 := nodes[0].localAddrPort()
 	nodes[1].Join(addr0)
 	nodes[2].Join(addr0)
+	<-nodes[0].Updates()
+	<-nodes[0].Updates()
+	<-nodes[1].Updates()
+	<-nodes[1].Updates()
+	<-nodes[2].Updates()
+	<-nodes[2].Updates()
 
 	s := "Hello, SWIM!"
 	nodes[0].Post([]byte(s))

--- a/swim_test.go
+++ b/swim_test.go
@@ -45,7 +45,7 @@ func TestDetectJoinAndFail(t *testing.T) {
 }
 
 func TestPost(t *testing.T) {
-	opt := diff.ZeroFields[Memo]("Addr")
+	opt := diff.ZeroFields[Update]("Addr")
 	nodes := launch(3)
 	addr0 := nodes[0].localAddrPort()
 	nodes[1].Join(addr0)
@@ -53,13 +53,13 @@ func TestPost(t *testing.T) {
 
 	s := "Hello, SWIM!"
 	nodes[0].Post([]byte(s))
-	m := Memo{NodeID: string(nodes[0].id), Body: []byte(s)}
-	diff.Test(t, t.Errorf, <-nodes[1].Memos(), m, opt)
-	diff.Test(t, t.Errorf, <-nodes[2].Memos(), m, opt)
+	u := Update{NodeID: string(nodes[0].id), IsMember: true, Body: []byte(s)}
+	diff.Test(t, t.Errorf, <-nodes[1].Updates(), u, opt)
+	diff.Test(t, t.Errorf, <-nodes[2].Updates(), u, opt)
 	nodes[1].Post([]byte(s))
-	m = Memo{NodeID: string(nodes[1].id), Body: []byte(s)}
-	diff.Test(t, t.Errorf, <-nodes[0].Memos(), m, opt)
-	diff.Test(t, t.Errorf, <-nodes[2].Memos(), m, opt)
+	u = Update{NodeID: string(nodes[1].id), IsMember: true, Body: []byte(s)}
+	diff.Test(t, t.Errorf, <-nodes[0].Updates(), u, opt)
+	diff.Test(t, t.Errorf, <-nodes[2].Updates(), u, opt)
 }
 
 func launch(n int) []*Node {

--- a/swim_test.go
+++ b/swim_test.go
@@ -13,7 +13,7 @@ func TestDetectJoinAndFail(t *testing.T) {
 	nodes := launch(2)
 	addr0 := nodes[0].localAddrPort()
 	update := func(n int, isMember bool) Update {
-		return Update{ID: string(nodes[n].id), IsMember: isMember}
+		return Update{NodeID: string(nodes[n].id), IsMember: isMember}
 	}
 	nodes[1].Join(addr0)
 	diff.Test(t, t.Errorf, <-nodes[0].Updates(), update(1, true), opt)
@@ -28,7 +28,7 @@ func TestDetectJoinAndFail(t *testing.T) {
 	updates2 := make(map[id]Update)
 	for i := 0; i < 2; i++ {
 		u := <-nodes[2].Updates()
-		updates2[id(u.ID)] = u
+		updates2[id(u.NodeID)] = u
 	}
 	want2 := map[id]Update{
 		nodes[0].id: update(0, true),
@@ -45,7 +45,7 @@ func TestDetectJoinAndFail(t *testing.T) {
 }
 
 func TestPostMemo(t *testing.T) {
-	opt := diff.ZeroFields[Memo]("SrcAddr")
+	opt := diff.ZeroFields[Memo]("Addr")
 	nodes := launch(3)
 	addr0 := nodes[0].localAddrPort()
 	nodes[1].Join(addr0)
@@ -53,11 +53,11 @@ func TestPostMemo(t *testing.T) {
 
 	s := "Hello, SWIM!"
 	nodes[0].PostMemo([]byte(s))
-	m := Memo{SrcID: string(nodes[0].id), Body: []byte(s)}
+	m := Memo{NodeID: string(nodes[0].id), Body: []byte(s)}
 	diff.Test(t, t.Errorf, <-nodes[1].Memos(), m, opt)
 	diff.Test(t, t.Errorf, <-nodes[2].Memos(), m, opt)
 	nodes[1].PostMemo([]byte(s))
-	m = Memo{SrcID: string(nodes[1].id), Body: []byte(s)}
+	m = Memo{NodeID: string(nodes[1].id), Body: []byte(s)}
 	diff.Test(t, t.Errorf, <-nodes[0].Memos(), m, opt)
 	diff.Test(t, t.Errorf, <-nodes[2].Memos(), m, opt)
 }

--- a/swim_test.go
+++ b/swim_test.go
@@ -44,7 +44,7 @@ func TestDetectJoinAndFail(t *testing.T) {
 	diff.Test(t, t.Errorf, <-nodes[1].Updates(), update(2, false), opt)
 }
 
-func TestPostMemo(t *testing.T) {
+func TestPost(t *testing.T) {
 	opt := diff.ZeroFields[Memo]("Addr")
 	nodes := launch(3)
 	addr0 := nodes[0].localAddrPort()
@@ -52,11 +52,11 @@ func TestPostMemo(t *testing.T) {
 	nodes[2].Join(addr0)
 
 	s := "Hello, SWIM!"
-	nodes[0].PostMemo([]byte(s))
+	nodes[0].Post([]byte(s))
 	m := Memo{NodeID: string(nodes[0].id), Body: []byte(s)}
 	diff.Test(t, t.Errorf, <-nodes[1].Memos(), m, opt)
 	diff.Test(t, t.Errorf, <-nodes[2].Memos(), m, opt)
-	nodes[1].PostMemo([]byte(s))
+	nodes[1].Post([]byte(s))
 	m = Memo{NodeID: string(nodes[1].id), Body: []byte(s)}
 	diff.Test(t, t.Errorf, <-nodes[0].Memos(), m, opt)
 	diff.Test(t, t.Errorf, <-nodes[2].Memos(), m, opt)

--- a/swim_test.go
+++ b/swim_test.go
@@ -44,7 +44,7 @@ func TestDetectJoinAndFail(t *testing.T) {
 	diff.Test(t, t.Errorf, <-nodes[1].Updates(), update(Failed, 2), opt)
 }
 
-func TestPost(t *testing.T) {
+func TestPostMemo(t *testing.T) {
 	opt := diff.ZeroFields[Update]("Addr")
 	nodes := launch(3)
 	addr0 := nodes[0].localAddrPort()


### PR DESCRIPTION
Unifying the parallel structure of the Update and Memo types simplifies and
clarifies the API and seems easier to work with.