### PR TITLE
treat memos as implying sender's liveness

### DIFF
--- a/fsm.go
+++ b/fsm.go
@@ -378,13 +378,10 @@ func (s *stateMachine) failedMessage(id id) *message {
 
 // addMemo adds a new memo carrying b to the memo queue.
 func (s *stateMachine) addMemo(b []byte) {
+	m := s.aliveMessage()
 	memoID := randID()
-	s.memoQueue.Upsert(memoID, &message{
-		Type:        alive,
-		NodeID:      s.id,
-		Incarnation: s.incarnation,
-		MemoID:      memoID,
-		Body:        b,
-	})
+	m.MemoID = memoID
+	m.Body = b
+	s.memoQueue.Upsert(memoID, m)
 	s.seenMemos[memoID] = true
 }

--- a/fsm.go
+++ b/fsm.go
@@ -62,7 +62,6 @@ const (
 	alive msgType = iota
 	suspected
 	failed
-	memo
 )
 
 // A message carries membership information or memo data.
@@ -182,7 +181,7 @@ func (s *stateMachine) processMsg(m *message) bool {
 		}
 		return m.Type != failed
 	}
-	if m.Type == memo && !s.seenMemos[m.MemoID] {
+	if len(m.Body) > 0 && !s.seenMemos[m.MemoID] {
 		s.seenMemos[m.MemoID] = true
 		s.memoQueue.Upsert(m.MemoID, m)
 		s.updates <- Update{
@@ -381,7 +380,7 @@ func (s *stateMachine) failedMessage(id id) *message {
 func (s *stateMachine) addMemo(b []byte) {
 	memoID := randID()
 	s.memoQueue.Upsert(memoID, &message{
-		Type:        memo,
+		Type:        alive,
 		NodeID:      s.id,
 		Incarnation: s.incarnation,
 		MemoID:      memoID,

--- a/fsm.go
+++ b/fsm.go
@@ -175,17 +175,14 @@ func (s *stateMachine) receive(p packet) ([]packet, bool) {
 // processMsg processes a received message and reports whether s can continue
 // participating in the protocol.
 func (s *stateMachine) processMsg(m *message) bool {
-	switch {
-	case m.NodeID == s.id:
+	if m.NodeID == s.id {
 		if m.Type == suspected && m.Incarnation == s.incarnation {
 			s.incarnation++
 			s.msgQueue.Upsert(s.id, s.aliveMessage())
 		}
 		return m.Type != failed
-	case m.Type == memo:
-		if s.seenMemos[m.MemoID] {
-			break
-		}
+	}
+	if m.Type == memo && !s.seenMemos[m.MemoID] {
 		s.seenMemos[m.MemoID] = true
 		s.memoQueue.Upsert(m.MemoID, m)
 		s.updates <- Update{
@@ -194,7 +191,8 @@ func (s *stateMachine) processMsg(m *message) bool {
 			Addr:   m.Addr,
 			Memo:   m.Body,
 		}
-	case s.isMemberNews(m):
+	}
+	if s.isMemberNews(m) {
 		s.updateStatus(m)
 		s.msgQueue.Upsert(m.NodeID, m)
 	}
@@ -286,9 +284,6 @@ func (s *stateMachine) isSuspect(id id) bool {
 // isMemberNews reports whether m contains new membership status information.
 func (s *stateMachine) isMemberNews(m *message) bool {
 	if m == nil {
-		return false
-	}
-	if m.Type == memo {
 		return false
 	}
 	id := m.NodeID
@@ -386,10 +381,11 @@ func (s *stateMachine) failedMessage(id id) *message {
 func (s *stateMachine) addMemo(b []byte) {
 	memoID := randID()
 	s.memoQueue.Upsert(memoID, &message{
-		Type:   memo,
-		NodeID: s.id,
-		MemoID: memoID,
-		Body:   b,
+		Type:        memo,
+		NodeID:      s.id,
+		Incarnation: s.incarnation,
+		MemoID:      memoID,
+		Body:        b,
 	})
 	s.seenMemos[memoID] = true
 }


### PR DESCRIPTION
Under the memo extension to the SWIM protocol, a memo implicitly indicates that
its sender is functioning. This is semantically reflected in the fact that the
only message types a node originates regarding itself are alive messages and
new memos. Making this correspondence explicit by including the sender's
incarnation number with each generated memo renders the `memo` msgType redundant.
