### PR TITLE
exclude memo data from message queue

### DIFF
--- a/fsm.go
+++ b/fsm.go
@@ -66,12 +66,10 @@ const (
 
 // A message carries membership information or memo data.
 type message struct {
-	Type   msgType
-	NodeID id
-	Addr   netip.AddrPort
-
-	// for alive, suspected, failed
-	Incarnation int `json:",omitempty"`
+	Type        msgType
+	NodeID      id
+	Addr        netip.AddrPort
+	Incarnation int
 
 	// for memo
 	MemoID id     `json:",omitempty"`
@@ -193,7 +191,7 @@ func (s *stateMachine) processMsg(m *message) bool {
 	}
 	if s.isMemberNews(m) {
 		s.updateStatus(m)
-		s.msgQueue.Upsert(m.NodeID, m)
+		s.msgQueue.Upsert(m.NodeID, stripMemo(m))
 	}
 	return true
 }
@@ -384,4 +382,13 @@ func (s *stateMachine) addMemo(b []byte) {
 	m.Body = b
 	s.memoQueue.Upsert(memoID, m)
 	s.seenMemos[memoID] = true
+}
+
+// stripMemo returns a copy of m without its memo data, if any.
+func stripMemo(m *message) *message {
+	n := new(message)
+	*n = *m
+	n.MemoID = ""
+	n.Body = nil
+	return n
 }

--- a/fsm_test.go
+++ b/fsm_test.go
@@ -1,6 +1,7 @@
 package swim
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -52,6 +53,37 @@ func TestIsMemberNews(t *testing.T) {
 	} {
 		if got := s.isMemberNews(tt.m); got != tt.want {
 			t.Errorf("isNews(%+v): got %v, expected %v", tt.m, got, tt.want)
+		}
+	}
+}
+
+func TestStripMemo(t *testing.T) {
+	for _, tt := range []struct {
+		in, want *message
+	}{
+		{
+			&message{Type: alive, NodeID: "abc", Incarnation: 2},
+			&message{Type: alive, NodeID: "abc", Incarnation: 2},
+		},
+		{
+			&message{
+				Type:        alive,
+				NodeID:      "abc",
+				Incarnation: 2,
+				MemoID:      "123",
+				Body:        []byte("Hello, SWIM!"),
+			},
+			&message{Type: alive, NodeID: "abc", Incarnation: 2},
+		},
+	} {
+		m := new(message)
+		*m = *tt.in
+		got := stripMemo(m)
+		if !reflect.DeepEqual(m, tt.in) {
+			t.Errorf("stripMemo(%v): input modified to %v", tt.in, m)
+		}
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("stripMemo(%v): got %v, expect %v", tt.in, got, tt.want)
 		}
 	}
 }


### PR DESCRIPTION
This commit fixes a bug by which memo-bearing messages are erroneously accepted into the message queue for membership status gossip with their memo data intact. This is an issue because membership status messages should be small so that several of them can be disseminated in each packet. This commit causes any memo data present to be stripped from a message bearing novel membership information before it is upserted into the message queue.